### PR TITLE
[CSR-1918] fix: continue cache set

### DIFF
--- a/dist/post.js
+++ b/dist/post.js
@@ -26204,7 +26204,8 @@ async function run() {
         const options = [
             `--preset last-run`,
             `--matrix-index ${state.matrixIndex}`,
-            `--matrix-total ${state.matrixTotal}`
+            `--matrix-total ${state.matrixTotal}`,
+            `--continue`
         ];
         if (state.key) {
             options.push(`--key ${state.key}`);

--- a/src/post.ts
+++ b/src/post.ts
@@ -37,7 +37,8 @@ async function run(): Promise<void> {
     const options: string[] = [
       `--preset last-run`,
       `--matrix-index ${state.matrixIndex}`,
-      `--matrix-total ${state.matrixTotal}`
+      `--matrix-total ${state.matrixTotal}`,
+      `--continue`
     ]
 
     if (state.key) {


### PR DESCRIPTION
Uses https://github.com/currents-dev/currents-reporter/pull/66 to prevent errors when no paths are found.


Luckily the `currents cache` command currently ignores unrecognized flags, so this doesn't break users with older versions of `cmd` installed.
