### PR TITLE
feat: add use-api option

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 name: 'Playwright Last Failed'
 description:
   'The action helps to run last failed Playwright tests using Currents cache'
-author: 'vCaisim'
+author: 'Currents Software Inc'
 
 inputs:
   key:
@@ -36,6 +36,10 @@ inputs:
     description: 'The total number of matrices available'
     required: false
     default: '1'
+  use-api:
+    description: 'Use Currents API for obtaining the list of failed tests'
+    required: false
+    default: 'false'
   or8n:
     description: 'Enable or8n integration'
     required: false

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { parseIntSafe, parseTemplate, parseYamlBoolean } from './utils'
 
 // Define interface for inputs
 interface ActionInputs {
+  useAPI: boolean
   or8n: boolean
   debug: boolean
   matrixIndex: string
@@ -22,6 +23,7 @@ interface ActionInputs {
 // Get inputs with types
 function getInputs(): ActionInputs {
   return {
+    useAPI: parseYamlBoolean(core.getInput('use-api')) ?? false,
     or8n: parseYamlBoolean(core.getInput('or8n')) ?? false,
     debug: parseYamlBoolean(core.getInput('debug')) ?? false,
     apiKey: core.getInput('api-key') ?? process.env.CURRENTS_API_KEY,
@@ -43,8 +45,9 @@ async function run(): Promise<void> {
 
     await exec.exec('npm install -g @currents/cmd')
 
-    core.saveState('or8n', inputs.or8n)
-    if (inputs.or8n) {
+    const useAPI = inputs.useAPI || inputs.or8n;
+    core.saveState('or8n', useAPI)
+    if (useAPI) {
       await or8n(inputs)
       return
     }

--- a/src/post.ts
+++ b/src/post.ts
@@ -14,7 +14,7 @@ interface PostState {
 
 function getPostState(): PostState {
   return {
-    or8n: core.getState('or8n') === 'true',
+    or8n: core.getState('or8n') === 'true' || core.getState('useAPI') === 'true',
     key: core.getState('key') ?? process.env.CURRENTS_RECORD_KEY,
     debug: core.getState('debug') === 'true',
     id: core.getState('id'),


### PR DESCRIPTION
Add `use-api` which is equivalent to `or8n`, reason being that some users want / need to use the API for getting the list of failed tests but do not use or8n and the naming is confusing. 