### PR TITLE
chore: bump version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "playwright-last-failed",
-  "version": "1.0.11",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "playwright-last-failed",
-      "version": "1.0.11",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "playwright-last-failed",
   "description": "GitHub Actions TypeScript template that runs last failed Playwright tests using Currents cache",
-  "version": "1.0.11",
+  "version": "1.1.2",
   "author": "",
   "private": true,
   "homepage": "https://github.com/actions/typescript-action",


### PR DESCRIPTION
Bump version to accurately have a tag newer then the existing 1.1.0

This jumps to 1.1.2  (I left 1.1.1 available in case we wanted to retag 1.0.11 as 1.1.1)

Fixes https://github.com/currents-dev/playwright-last-failed/issues/44