### PR TITLE
fix: Don't fail in apiMode when getting 404 not-founds on the build ID [CSR-3062]

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -42980,7 +42980,9 @@ async function or8n(inputs) {
             `--output`,
             `${lastRunFilePath}`
         ];
-        const exitCode = await exec.exec(`npx currents api get-run ${options.join(' ')}`);
+        const exitCode = await exec.exec(`npx currents api get-run ${options.join(' ')}`, [], {
+            ignoreReturnCode: true
+        });
         if (exitCode === 0) {
             core.setOutput('extra-pw-flags', '--last-failed');
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,7 +126,11 @@ async function or8n(inputs: ActionInputs): Promise<void> {
       `${lastRunFilePath}`
     ]
     const exitCode = await exec.exec(
-      `npx currents api get-run ${options.join(' ')}`
+      `npx currents api get-run ${options.join(' ')}`,
+      [],
+      {
+        ignoreReturnCode: true
+      }
     )
 
     if (exitCode === 0) {


### PR DESCRIPTION
Fixes https://github.com/currents-dev/playwright-last-failed/issues/56

## Description

There was a bug in our useAPI mode where we where erroring out the action for notFound. This was already fixed for sharding mode as part of the initial release, but was missed. Applied the same change to ensure the command doesn't fail the action.


## Demo

Here is the log output from a sample run retry with this branch: https://github.com/twk3/playwright-gh-actions-demo/actions/runs/17507043195/job/49732490763  not the action passes and all tests are run again despite the 404 in the last-failed action log

## Manual Testing

- You can reproduce the problem by enabling `useApi: true`, and setting `previous-ci-build-id` to something that isn't the actual build Id. (though the previous ci build id template doesn't have to be *wrong* for this to happen in the real world, the run just has to have not been created, maybe there was nothing to do, etc).
- Without this change
   * The server throws a 404 for the missing run, and the action fails
- With this change
   * The server throws a 404 for the missing run, but the action doesn't fail, and instead there is no last-run file. So playwright will start running all the tests. (which is the safest option)