### PR TITLE
feat: release v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "playwright-last-failed",
-  "version": "1.1.5",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "playwright-last-failed",
-      "version": "1.1.5",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "playwright-last-failed",
   "description": "GitHub Actions TypeScript template that runs last failed Playwright tests using Currents cache",
-  "version": "1.1.5",
+  "version": "2.0.0",
   "author": "",
   "private": true,
   "homepage": "https://github.com/actions/typescript-action",


### PR DESCRIPTION
- with updated actions core, and node24 support

Our actions core dependencies were updated to v2 in 

- https://github.com/currents-dev/playwright-last-failed/pull/80
- https://github.com/currents-dev/playwright-last-failed/pull/89

we went to actions/core v2 instead of v3 because v2 supports node24 (actions skipped node22, and node20 is going away). And v2 still isn't an ESM only package. (v3 is ESM only).

Sticking with V2 should hopefully keep us compatible with both older and newer pipelines for a little while longer.